### PR TITLE
Add manual install instructions for ubuntu.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,17 +25,7 @@ Files from the packages are installed in `~/.dotties/packages/${USERNAME-REPO}`
 and are never modified by dotties, so feel free to update these files in place
 and commit them back to GitHub.
 
-## Usage
-
-### Requirements
-
-* Mac OS X
-* [Homebrew](http://brew.sh/)
-
-* Ubuntu
-* Manual Install
-
-### Installing
+## Insalling on OS X
 
 You can install dotties from [Homebrew](http://brew.sh/).
 
@@ -44,22 +34,28 @@ brew tap tinytacoteam/formulae
 brew install dotties
 ~~~
 
-### Manual Install (Ubuntu)
+## Installing on Ubuntu
 
-#### Install rvm
+### Install rvm
+
+~~~
 gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 \curl -sSL https://get.rvm.io | bash
 source /etc/profile.d/rvm.sh
 rvm install ruby-2.2
+~~~
 
-#### Install dotties
+### Install dotties
+
+~~~
 cd /tmp
 git clone https://github.com/tinytacoteam/dotties-core.git
 cd dotties-core/bin
 mv ../lib /usr/local/bin/.dotties-lib
 cat dotties | sed -e 's|../lib|.dotties-lib|g' > /usr/local/bin/dotties
+~~~
 
-### Getting started
+## Getting started
 
 Create a repo on GitHub with your dotfiles inside of it.
 
@@ -82,7 +78,7 @@ To install a repo simply run:
 dotties install blainesch/dotties
 ~~~
 
-### .dotties.yml
+## .dotties.yml
 
 Optionally, you can have a `.dotties.yml` if you wish to include additional
 packages or you want to ignore files such as a `readme` or pictures of your dog.

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ cd /tmp
 git clone https://github.com/tinytacoteam/dotties-core.git
 cd dotties-core/bin
 mv ../lib /usr/local/bin/.dotties-lib
-cat dotties | sed -e 's|../lib|dotties-lib|g' > /usr/local/bin/dotties
+cat dotties | sed -e 's|../lib|.dotties-lib|g' > /usr/local/bin/dotties
 
 ### Getting started
 

--- a/readme.md
+++ b/readme.md
@@ -57,8 +57,7 @@ cd /tmp
 git clone https://github.com/tinytacoteam/dotties-core.git
 cd dotties-core/bin
 mv ../lib .dotties-lib
-mv dotties /usr/local/bin/dotties
-mv .dotties-lib /usr/local/bin/.dotties-lib
+cat dotties | sed -e 's|../lib|dotties-lib|g' > /usr/local/bin/dotties
 
 ### Getting started
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,9 @@ and commit them back to GitHub.
 * Mac OS X
 * [Homebrew](http://brew.sh/)
 
+* Ubuntu
+* Manual Install
+
 ### Installing
 
 You can install dotties from [Homebrew](http://brew.sh/).
@@ -40,6 +43,22 @@ You can install dotties from [Homebrew](http://brew.sh/).
 brew tap tinytacoteam/formulae
 brew install dotties
 ~~~
+
+### Manual Install (Ubuntu)
+
+#### Install rvm
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+\curl -sSL https://get.rvm.io | bash
+source /etc/profile.d/rvm.sh
+rvm install ruby-2.2
+
+#### Install dotties
+cd /tmp
+git clone https://github.com/tinytacoteam/dotties-core.git
+cd dotties-core/bin
+mv ../lib .dotties-lib
+mv dotties /usr/local/bin/dotties
+mv .dotties-lib /usr/local/bin/.dotties-lib
 
 ### Getting started
 

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ rvm install ruby-2.2
 cd /tmp
 git clone https://github.com/tinytacoteam/dotties-core.git
 cd dotties-core/bin
-mv ../lib .dotties-lib
+mv ../lib /usr/local/bin/.dotties-lib
 cat dotties | sed -e 's|../lib|dotties-lib|g' > /usr/local/bin/dotties
 
 ### Getting started


### PR DESCRIPTION
Needed `dotties` on a `ubuntu vagrant box`, and thought I would share the steps I took. 

This is a WIP since it looks like some `dotties` functionality is not currently working inside ubuntu.